### PR TITLE
Add .snap to .gitignore

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,10 +18,16 @@ jobs:
     - name: Lint with flake8
       run: |
         tox -elint
-  snap-build:
+  build-and-run-snap:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: snapcore/action-build@v1
-  snap-test:
-    needs: snap-build
+      id: snapcraft
+    - uses: actions/upload-artifact@v2
+      with:
+        name: snap
+        path: ${{ steps.snapcraft.outputs.snap }}
+    - run: |
+        sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}
+        ubuntu-package-changelog -h

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 *.pyc
 .tox
 *~
+*.snap


### PR DESCRIPTION
Locally built snap packages should not land in git.