### PR TITLE
Drop --lines parameter, add --entries with default to 1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ ubuntu-package-changelog
 `ubuntu-package-changelog` can be used to get a changelog for
 a given Ubuntu source package. Eg::
 
-  ubuntu-package-changelog focal Updates linux-azure --lines 12
+  ubuntu-package-changelog focal Updates linux-azure
   linux-azure (5.4.0-1043.45) focal; urgency=medium
 
     [ Ubuntu: 5.4.0-70.78 ]
@@ -18,6 +18,8 @@ a given Ubuntu source package. Eg::
 
    -- Thadeu Lima de Souza Cascardo <cascardo@canonical.com>  Fri, 19 Mar 2021 13:32:55 -0300
 
+By default, only the latest changelog entry is shown. To see more entries, use the `--entries`
+flag.
 It's also possible to get a changelog for a package in a PPA::
 
   ubuntu-package-changelog -ppa cloud-images/eks-01.11.0 focal Release cni

--- a/ubuntu_package_changelog/__init__.py
+++ b/ubuntu_package_changelog/__init__.py
@@ -49,8 +49,8 @@ def _parser():
                         'of the Ubuntu archive. Given PPA must have the '
                         'format "owner/ppa-name". Eg. "toabctl/testing"',
                         type=_args_validate_ppa_name)
-    parser.add_argument('--lines', help='number of lines to get from the changelog. '
-                        '0 mean all. Default: %(default)s', type=int, default=0)
+    parser.add_argument('--entries', help='number of changelog entries to get from the '
+                        'changelog. 0 mean all. Default: %(default)s', type=int, default=1)
     parser.add_argument('series', help='the Ubuntu series eg. "20.04" or "focal"')
     parser.add_argument('pocket',
                         choices=['Release', 'Security', 'Updates', 'Proposed', 'Backports'],
@@ -68,10 +68,15 @@ def main():
         sys.exit(0)
 
     with urllib.request.urlopen(changelog_url) as response:
-        for count, line in enumerate(response.readlines()):
-            if args.lines > 0 and count > args.lines:
+        entry_count = 0
+        for line in response.readlines():
+            line = line.rstrip().decode('utf-8')
+            if line.startswith(' -- '):
+                entry_count += 1
+            if args.entries > 0 and entry_count >= args.entries:
+                print(line)
                 break
-            print(line.rstrip().decode('utf-8'))
+            print(line)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Instead of using --lines to limit the amount of changelog entries, add
--entries (which defaults now to 1) for better usability.
With that, calling ubuntu-package-changelog now only shows the latest
changelog entry by default.

Note: this change does break the CLI usage if you used --lines
before.