### PR TITLE
snap: add libffi-dev build-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,3 +27,4 @@ parts:
     source: .
     build-packages:
       - python3-setuptools-scm
+      - libffi-dev


### PR DESCRIPTION
This hopefully fixes some build failures on eg. armhf.