### PR TITLE
snap: add rustc build-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,4 +27,6 @@ parts:
     source: .
     build-packages:
       - python3-setuptools-scm
+      # for python cryptography
       - libffi-dev
+      - rustc


### PR DESCRIPTION
This hopefully fixes the build for some architectures. rustc in needed
for cryptography.