### PR TITLE
snap: add cargo build-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,3 +30,4 @@ parts:
       # for python cryptography
       - libffi-dev
       - rustc
+      - cargo


### PR DESCRIPTION
This hopefully fixes the build for some architectures. cargo in needed
for cryptography.