### PR TITLE
snap: add libssl-dev build-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,3 +31,4 @@ parts:
       - libffi-dev
       - rustc
       - cargo
+      - libssl-dev


### PR DESCRIPTION
This hopefully fixes the build for some architectures. libssl-dev in
needed for cryptography.