### PR TITLE
snap: mark snap grade as stable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,7 +9,7 @@ description: |
   Example usage:
   ubuntu-package-changelog focal Updates linux-azure --lines 12
 
-grade: devel
+grade: stable
 confinement: strict
 
 apps:


### PR DESCRIPTION
Needed to be able to release to a stable channel on the snapstore.