### PR TITLE
Fix used username for launchpad login

### DIFF
--- a/ubuntu_package_changelog/__init__.py
+++ b/ubuntu_package_changelog/__init__.py
@@ -61,7 +61,7 @@ def main():
     args = parser.parse_args()
     if args.lp_user:
         lp = Launchpad.login_with(
-            'toabctl',
+            args.lp_user,
             'production', version='devel')
     else:
         lp = Launchpad.login_anonymously(


### PR DESCRIPTION
Commit 0d1afa0584e88 added a hardcoded username instead of using the
provided CLI argument. This is now fixed.