### PR TITLE
snap: add password-manager-service plug

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,11 @@ For installation, do::
 
   snap install ubuntu-package-changelog
 
+To access private PPAs, it's useful to connect the `password-manager-service`
+so authorization is only done once::
+
+  snap connect ubuntu-package-changelog:password-manager-service
+
 The other option is installing it into a `virtualenv`::
 
   virtualenv venv

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ apps:
     command: bin/ubuntu-package-changelog
     plugs:
       - network
+      - password-manager-service
     environment:
        LC_ALL: C.UTF-8
        PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$SNAP/lib/python3.8/site-packages/


### PR DESCRIPTION
That's needed to be able to store the LP access token in the password
manager. Otherwise, with every call you need to authorize application
access via the browser.