### PR TITLE
Feature/support use changelogs ubuntu com

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ package_dir=
   =.
 packages = find:
 install_requires =
-  launchpadlib
+  launchpadlib requests
 setup_requires =
   setuptools_scm
   

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,8 @@ package_dir=
   =.
 packages = find:
 install_requires =
-  launchpadlib requests
+  launchpadlib
+  requests
 setup_requires =
   setuptools_scm
   

--- a/ubuntu_package_changelog/__init__.py
+++ b/ubuntu_package_changelog/__init__.py
@@ -7,6 +7,7 @@ import urllib.parse
 import requests
 from launchpadlib.launchpad import Launchpad
 
+
 def _get_changelogs_ubuntu_com_changelog(package_name):
     """
     Return changelog for sourc package
@@ -47,8 +48,8 @@ def _get_changelogs_ubuntu_com_changelog(package_name):
         latest_version = m.group("version")
         break
 
-
-    # Changelog URL example http://changelogs.ubuntu.com/changelogs/pool/main/l/linux-gkeop/linux-gkeop_5.4.0-1048.51/changelog
+    # Changelog URL example http://changelogs.ubuntu.com/changelogs/pool/main\
+    # /l/linux-gkeop/linux-gkeop_5.4.0-1048.51/changelog
     changelog_url = "{}/{}/{}/{}_{}/changelog".format(
         changelog_base_url,
         package_prefix,
@@ -57,11 +58,9 @@ def _get_changelogs_ubuntu_com_changelog(package_name):
         latest_version,
         )
 
-
     changelog_reponse = requests.get(changelog_url)
     changelog = changelog_reponse.text
     return changelog
-
 
 
 def _lp_get_changelog_url(args, lp):


### PR DESCRIPTION
feat: Add support for downloading changelogs from changelogs.ubuntu.com

Using new arg `--use-changelogs-ubuntu-com` will download changelog direct from
changelogs.ubuntu.com instead of querying launchpad API.

This is useful if it is a kernel that was copied from a private PPA,
for example during an embargoed CVE where the public build for that source
package will not be the most recent and will not contain the most recent
changelog. This option assumes that the package is in the main Ubuntu archive.
