### PR TITLE
fix: do correctly login to really use production LP

### DIFF
--- a/ubuntu_package_changelog/__init__.py
+++ b/ubuntu_package_changelog/__init__.py
@@ -65,6 +65,7 @@ def main():
             'production', version='devel')
     else:
         lp = Launchpad.login_anonymously(
+            'ubuntu-package-changelog',
             'production', version='devel')
 
     changelog_url = _lp_get_changelog_url(args, lp)


### PR DESCRIPTION
Launchpad.login_anonymously() expects as first parameter the
consumer_name. And that was set to "production" (instead of the
service_root). This commit fixes this so really the production
launchpad env is now used.