### PR TITLE
fix: ensure keyring module is installed and available to use when querying private PPAs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ package_dir=
   =.
 packages = find:
 install_requires =
+  keyring
   launchpadlib
 setup_requires =
   setuptools_scm


### PR DESCRIPTION
Similar to https://github.com/canonical/ubuntu-package-status/pull/9/commits for ubuntu-package-status `keyring` is required when accessing private PPAs.

This fixes error when run as a snap.

```
Traceback (most recent call last):
  File "/snap/ubuntu-package-changelog/159/bin/ubuntu-package-changelog", line 8, in <module>
    sys.exit(main())
  File "/snap/ubuntu-package-changelog/159/lib/python3.8/site-packages/ubuntu_package_changelog/__init__.py", line 109, in main
    lp = Launchpad.login_with(
  File "/snap/ubuntu-package-changelog/159/lib/python3.8/site-packages/launchpadlib/launchpad.py", line 700, in login_with
    return cls._authorize_token_and_login(
  File "/snap/ubuntu-package-changelog/159/lib/python3.8/site-packages/launchpadlib/launchpad.py", line 445, in _authorize_token_and_login
    cached_credentials = credential_store.load(
  File "/snap/ubuntu-package-changelog/159/lib/python3.8/site-packages/launchpadlib/credentials.py", line 345, in load
    return self.do_load(unique_key)
  File "/snap/ubuntu-package-changelog/159/lib/python3.8/site-packages/launchpadlib/credentials.py", line 423, in do_load
    self._ensure_keyring_imported()
  File "/snap/ubuntu-package-changelog/159/lib/python3.8/site-packages/launchpadlib/credentials.py", line 388, in _ensure_keyring_imported
    import keyring
ModuleNotFoundError: No module named 'keyring'

```